### PR TITLE
add "continue_on_error" for create-run action in speculative template

### DIFF
--- a/workflows/terraform-cloud.speculative-run.workflow.yml
+++ b/workflows/terraform-cloud.speculative-run.workflow.yml
@@ -46,6 +46,8 @@ jobs:
 
       - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.2
         id: run
+        ## Allows job to continue on if any phase of the run errors
+        continue_on_error: true
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           configuration_version: ${{ steps.upload.outputs.configuration_version_id }}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links or related PR's here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
