### PR TITLE
Prepare v1.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+# v1.0.3
+* Bug fixes and enchancements form [tfc-workflows-tolling@v1.0.3](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.3) version bump
+
 # v1.0.2
 * Bug fixes and enhancements from [tfc-workflows-tooling@v1.0.2](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.2) version bump
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # UNRELEASED
 
 # v1.0.3
-* Bug fixes and enchancements form [tfc-workflows-tolling@v1.0.3](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.3) version bump
+* Bug fixes and enhancements from [tfc-workflows-tolling@v1.0.3](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.3) version bump
+* Adds run status check step to speculative run template by @mjyocca [#17](https://github.com/hashicorp/tfc-workflows-github/pull/17)
 
 # v1.0.2
 * Bug fixes and enhancements from [tfc-workflows-tooling@v1.0.2](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.2) version bump

--- a/actions/apply-run/action.yml
+++ b/actions/apply-run/action.yml
@@ -38,7 +38,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/actions/cancel-run/action.yml
+++ b/actions/cancel-run/action.yml
@@ -36,7 +36,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/actions/create-run/action.yml
+++ b/actions/create-run/action.yml
@@ -62,7 +62,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/actions/discard-run/action.yml
+++ b/actions/discard-run/action.yml
@@ -36,7 +36,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
     - tfci
     ## global flags

--- a/actions/plan-output/action.yml
+++ b/actions/plan-output/action.yml
@@ -39,7 +39,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/actions/show-run/action.yml
+++ b/actions/show-run/action.yml
@@ -48,7 +48,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/actions/upload-configuration/action.yml
+++ b/actions/upload-configuration/action.yml
@@ -43,7 +43,7 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.2'
+  image: 'docker://hashicorp/tfci:v1.0.3'
   args:
   - tfci
   ## global flags

--- a/workflow-templates/terraform-cloud.apply-run.workflow.yml
+++ b/workflow-templates/terraform-cloud.apply-run.workflow.yml
@@ -41,19 +41,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.3
         id: upload
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           directory: ${{ env.CONFIG_DIRECTORY }}
 
-      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.3
         id: create-run
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
 
-      - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.0.3
         id: apply
         if: ${{ fromJSON(steps.create-run.outputs.payload).data.attributes.actions.IsConfirmable }}
         with:

--- a/workflow-templates/terraform-cloud.speculative-run.workflow.yml
+++ b/workflow-templates/terraform-cloud.speculative-run.workflow.yml
@@ -46,6 +46,9 @@ jobs:
 
       - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.3
         id: run
+        ## run may fail, if so continue to output PR comment
+        ## step.terraform-cloud-check-run-status will fail job after pr comment is created/updated.
+        continue-on-error: true
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           configuration_version: ${{ steps.upload.outputs.configuration_version_id }}
@@ -97,3 +100,11 @@ jobs:
               })
             }
 
+        ## Check Run Status, if not planned_and_finished fail the job
+      - id: terraform-cloud-check-run-status
+        if: ${{ steps.run.outputs.run_status != 'planned_and_finished'}}
+        run: |
+          echo "Terraform Cloud Run Failed or Requires Further Attention"
+          echo "Run Status: '${{ steps.run.outputs.run_status }}'"
+          echo "${{ steps.run.outputs.run_link }}"
+          exit 1

--- a/workflow-templates/terraform-cloud.speculative-run.workflow.yml
+++ b/workflow-templates/terraform-cloud.speculative-run.workflow.yml
@@ -37,14 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.3
         id: upload
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           directory: ${{ env.CONFIG_DIRECTORY }}
           speculative: true
 
-      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.3
         id: run
         with:
           workspace: ${{ env.TF_WORKSPACE }}
@@ -54,7 +54,7 @@ jobs:
           ## Example:
           # message: "Triggered From GitHub Actions CI ${{ github.sha }}"
 
-      - uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.0.2
+      - uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.0.3
         id: plan-output
         with:
           plan: ${{ steps.run.outputs.plan_id }}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

* Version bumps all action.yml references to [hashicorp/tfci](https://github.com/hashicorp/tfc-workflows-tooling) to `@v1.0.3`
* Includes the following changes to speculative plan template:
  - `continue-on-error: true` step attribute to create-run action invocation, to allow PR comment to be created/updated.
  - [Run Status check](https://github.com/hashicorp/tfc-workflows-github/blob/15c5456689c7a2e7edde3fba2dd67f998d19b25e/workflows/terraform-cloud.speculative-run.workflow.yml#L104) to fail job if desired status is not `planned_and_finished`.

## External links

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/32)

