### PR TITLE
docs: clarify directory is relative to workspace working directory

### DIFF
--- a/actions/upload-configuration/action.yml
+++ b/actions/upload-configuration/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "The name of the workspace to create the new configuration version in."
   directory:
     required: true
-    description: "Path to the configuration files on disk. If the Terraform Working Directory is configured in the workspace the path is relative to this."
+    description: "Path to the configuration files on disk. Relative to the working directory of the workspace if configured"
   # optional
   speculative:
     required: false
@@ -43,15 +43,15 @@ outputs:
 
 runs:
   using: docker
-  image: 'docker://hashicorp/tfci:v1.0.4'
+  image: "docker://hashicorp/tfci:v1.0.4"
   args:
-  - tfci
-  ## global flags
-  - -hostname=${{ inputs.hostname }}
-  - -token=${{ inputs.token }}
-  - -organization=${{ inputs.organization }}
-  ## command arguments
-  - upload
-  - -workspace=${{ inputs.workspace }}
-  - -directory=${{ inputs.directory }}
-  - -speculative=${{ inputs.speculative }}
+    - tfci
+    ## global flags
+    - -hostname=${{ inputs.hostname }}
+    - -token=${{ inputs.token }}
+    - -organization=${{ inputs.organization }}
+    ## command arguments
+    - upload
+    - -workspace=${{ inputs.workspace }}
+    - -directory=${{ inputs.directory }}
+    - -speculative=${{ inputs.speculative }}

--- a/actions/upload-configuration/action.yml
+++ b/actions/upload-configuration/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "The name of the workspace to create the new configuration version in."
   directory:
     required: true
-    description: "Path to the configuration files on disk."
+    description: "Path to the configuration files on disk. If the Terraform Working Directory is configured in the workspace the path is relative to this."
   # optional
   speculative:
     required: false


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
The directory is relative to the workspace directory configuration option of the workspace but this wasn't mentioned in the documentation

<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links or related PR's here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
