### PR TITLE
Docs: Change `TF_ORGANIZATION` to `TF_CLOUD_ORGANIZATION`

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -20,7 +20,7 @@ For convenience, you are also able to specify these values within the GitHub Act
 
 ### `organization`
 
-**Optional** The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable.
+**Optional** The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable.
 
 ## Environment Variables
 
@@ -28,7 +28,7 @@ For convenience, you are also able to specify these values within the GitHub Act
 | ----------------- |--------------------| ---------------------------------------------------------------------------------------------------------------- |
 | `TF_HOSTNAME`     | `app.terraform.io` | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise. Defaults to Terraform Cloud. |
 | `TF_API_TOKEN`    | `n/a`              | The token used to authenticate with Terraform Cloud. [API Token Docs](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens)                                                           |
-| `TF_ORGANIZATION` | `n/a`              | The name of the organization in Terraform Cloud.                                                                 |
+| `TF_CLOUD_ORGANIZATION` | `n/a`              | The name of the organization in Terraform Cloud.                                                                 |
 | `TF_MAX_TIMEOUT`  | `1h`               | Max wait timeout to wait for actions to reach desired or errored state. ex: `1h30`, `30m`                                         |
 | `TF_VAR_*`        | `n/a`              | Only applicable for create-run action. Note: strings must be escaped. ex: `TF_VAR_image_id="\"ami-abc123\""`. All values must be expressed as an HCL literal in the same syntax you would use when writing Terraform code. [Create Run API Docs](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run)                                 |
 | `TF_LOG`          | `OFF`              | Debugging log level options: `OFF`, `ERROR`, `INFO`, `DEBUG`                                                     |

--- a/actions/apply-run/action.yml
+++ b/actions/apply-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable."
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable."
     default: ""
   # required
   run:

--- a/actions/cancel-run/action.yml
+++ b/actions/cancel-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable."
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable."
     default: ""
   run:
     required: true

--- a/actions/create-run/action.yml
+++ b/actions/create-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   ## required
   workspace:

--- a/actions/discard-run/action.yml
+++ b/actions/discard-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   run:
     required: true

--- a/actions/plan-output/action.yml
+++ b/actions/plan-output/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   ## required
   plan:

--- a/actions/show-run/action.yml
+++ b/actions/show-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   run:
     required: true

--- a/actions/upload-configuration/action.yml
+++ b/actions/upload-configuration/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   # required
   workspace:

--- a/actions/workspace-output/action.yml
+++ b/actions/workspace-output/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
   organization:
     required: false
-    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_ORGANIZATION` environment variable"
+    description: "The name of the organization in Terraform Cloud. Defaults to reading `TF_CLOUD_ORGANIZATION` environment variable"
     default: ""
   # required
   workspace:


### PR DESCRIPTION
## Description

In the documents, `TF_ORGANIZATION` is referenced as the default vault for `organization` input (if we don't explicitly set it via `with.organization`. However, the underlying tool uses `TF_CLOUD_ORGANIZATION` as the default one.
In the example workflows `TF_CLOUD_ORGANIZATION` is indicated, however, in the actual action input comments, `TF_ORGANIZATION` is referenced probably due to a typo.

This PR fixes #32.

## Testing plan

Try to use the Upload Configuration action by specifying `TF_ORGANIZATION` and omitting `with.organization`. It'll result in:
```
error uploading configuration version to Terraform Cloud: invalid value for organization
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 1 [running]:
reflect.Value.Type({0x0?, 0x0?, 0x[11](https://github.com/PashmakGuru/clusters/actions/runs/7304351620/job/19906395310#step:4:12)0?})
	/usr/local/go/src/reflect/value.go:2453 +0x[12](https://github.com/PashmakGuru/clusters/actions/runs/7304351620/job/19906395310#step:4:13)e
github.com/hashicorp/tfci/internal/command.(*outputMessage).Value(0xc0001cc5d0)
	/src/internal/command/output.go:39 +0xf9
github.com/hashicorp/tfci/internal/command.(*Meta).closeOutput(0xc0004540f0)
	/src/internal/command/meta.go:121 +0x12b
github.com/hashicorp/tfci/internal/command.(*UploadConfigurationCommand).Run(0xc0001cc510, {0xc00001e0d0, 0x3, 0x3})
	/src/internal/command/upload.go:63 +0x61d
github.com/mitchellh/cli.(*CLI).Run(0xc000[14](https://github.com/PashmakGuru/clusters/actions/runs/7304351620/job/19906395310#step:4:15)1a40)
	/go/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x5f8
main.realMain()
	/src/main.go:61 +0xf6
main.main()
	/src/main.go:46 +0x1b4
```

## External links

- [Terraform Cloud CLI Behavior](https://developer.hashicorp.com/terraform/cli/cloud/settings#tf_cloud_organization)