### PR TITLE
Renaming `GITHUB_TOKEN` to `GH_TOKEN`

### DIFF
--- a/workflow-templates/hcp-terraform.speculative-run.workflow.yml
+++ b/workflow-templates/hcp-terraform.speculative-run.workflow.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             // 1. Retrieve existing bot comments for the PR
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
Per the [GitHub Actions docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#naming-your-secrets), secrets cannot be prefixed with `GITHUB_`. This change is amending `GITHUB_TOKEN` to `GH_TOKEN`, which does not violate these rules.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Attempt to create a repository secret for Actions called `GITHUB_TOKEN`. An error will be thrown and the secret will not be created.
2. Attempt to create a repository secret for Actions called `GH_TOKEN`. It will be created properly
3. Update the example speculative plan on PR workflow to use `GH_TOKEN`.
4. Create a PR which has terraform changes, the comment with speculative run information and link to HCP Terraform will be included.
## External links

<!--
_Include any links or related PR's here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)

-->
GitHub Actions [secrets docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#naming-your-secrets)