### PR TITLE
Update docs to explain how to set permissions on `GITHUB_TOKEN`

### DIFF
--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -9,4 +9,5 @@
 ## Important Resources
 * [GitHub Actions Documentation](https://docs.github.com/en/actions)
 * [GitHub Assigning Permissions to Jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
+* [GitHub setting permissions for `GITHUB_TOKEN`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)
 * [HCP Terraform Documentation](https://developer.hashicorp.com/terraform/cloud-docs)

--- a/workflow-templates/hcp-terraform.speculative-run.workflow.yml
+++ b/workflow-templates/hcp-terraform.speculative-run.workflow.yml
@@ -63,6 +63,8 @@ jobs:
           plan: ${{ steps.run.outputs.plan_id }}
 
       ## REQUIRED: Workflow permissions: `Read and write permissions`
+      ## GITHUB_TOKEN is the built in token provided by GitHub Actions. It will need to be set to "permissive" in your repository settings
+      ## More information can be found here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
The Speculative Run workflow uses `GITHUB_TOKEN` to add HCP TF links in the PR comments. However, this requires specific permissions to be set for the repo secrets. This change adds some information to the docs and comments in the workflow that will helps users make sure they have made these changes to their repo settings.

## Testing plan

N/A, this is an addition in the documentation/comments

## External links


- [Initial PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/2975)
- [GitHub Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)
